### PR TITLE
Use Qt's undo system instead of 3rdparty/qt-undo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ Slate's goal is to simplify the creation of seamless tilesets.
 ### Dependencies ###
 
 * Qt >= 5.8
-* https://github.com/mitchcurtis/qt-undo
 * https://github.com/mitchcurtis/pickawinner
 
-qt-undo and pickawinner can be cloned and built separately, but they are also available as submodules of Slate's repo, and can therefore be built automatically when
+pickawinner can be cloned and built separately, but is also available as submodules of Slate's repo, and can therefore be built automatically when
 Slate is built, by first running the following commands:
 
     cd <slate-source-dir>

--- a/app/app.pri
+++ b/app/app.pri
@@ -1,4 +1,4 @@
-QT += widgets qml quick undo
+QT += widgets qml quick
 CONFIG += c++11
 
 INCLUDEPATH += $$PWD

--- a/app/application.cpp
+++ b/app/application.cpp
@@ -21,6 +21,7 @@
 
 #include <QFontDatabase>
 #include <QLoggingCategory>
+#include <QUndoStack>
 
 #include "tilecanvas.h"
 #include "tilecanvaspane.h"
@@ -68,9 +69,9 @@ Application::Application(int &argc, char **argv, const QString &applicationName)
     qmlRegisterType<TileGrid>("App", 1, 0, "TileGrid");
 
     // For some reason, only when debugging, I get
-    // QMetaProperty::read: Unable to handle unregistered datatype 'UndoStack*' for property 'Project_QML_108::undoStack'
+    // QMetaProperty::read: Unable to handle unregistered datatype 'QUndoStack*' for property 'Project_QML_108::undoStack'
     // if I don't do this.
-    qRegisterMetaType<UndoStack*>();
+    qRegisterMetaType<QUndoStack*>();
     qRegisterMetaType<Tile*>();
     qRegisterMetaType<Tileset*>();
 

--- a/app/applypixelerasercommand.cpp
+++ b/app/applypixelerasercommand.cpp
@@ -24,8 +24,8 @@
 Q_LOGGING_CATEGORY(lcApplyPixelEraserCommand, "app.applyPixelEraserCommand")
 
 ApplyPixelEraserCommand::ApplyPixelEraserCommand(TileCanvas *canvas, const QVector<QPoint> &scenePositions,
-    const QVector<QColor> &previousColours, UndoCommand *parent) :
-    UndoCommand(parent),
+    const QVector<QColor> &previousColours, QUndoCommand *parent) :
+    QUndoCommand(parent),
     mCanvas(canvas)
 {
     mScenePositions = scenePositions;
@@ -53,9 +53,9 @@ int ApplyPixelEraserCommand::id() const
     return TileCanvas::PixelMode;
 }
 
-bool ApplyPixelEraserCommand::mergeWith(const UndoCommand *other)
+bool ApplyPixelEraserCommand::mergeWith(const QUndoCommand *other)
 {
-    const ApplyPixelEraserCommand *otherCommand = qobject_cast<const ApplyPixelEraserCommand*>(other);
+    const ApplyPixelEraserCommand *otherCommand = dynamic_cast<const ApplyPixelEraserCommand*>(other);
     if (!otherCommand) {
         return false;
     }

--- a/app/applypixelerasercommand.h
+++ b/app/applypixelerasercommand.h
@@ -24,23 +24,21 @@
 #include <QDebug>
 #include <QPoint>
 #include <QVector>
-#include <QtUndo/undocommand.h>
+#include <QUndoCommand>
 
 #include "tilecanvas.h"
 
-class ApplyPixelEraserCommand : public UndoCommand
+class ApplyPixelEraserCommand : public QUndoCommand
 {
-    Q_OBJECT
-
 public:
     ApplyPixelEraserCommand(TileCanvas *canvas, const QVector<QPoint> &scenePositions, const QVector<QColor> &previousColours,
-        UndoCommand *parent = nullptr);
+        QUndoCommand *parent = nullptr);
 
     void undo() override;
     void redo() override;
 
     int id() const override;
-    bool mergeWith(const UndoCommand *other) override;
+    bool mergeWith(const QUndoCommand *other) override;
 
 private:
     friend QDebug operator<<(QDebug debug, const ApplyPixelEraserCommand &command);

--- a/app/applypixelfillcommand.cpp
+++ b/app/applypixelfillcommand.cpp
@@ -24,8 +24,8 @@
 Q_LOGGING_CATEGORY(lcApplyPixelFillCommand, "app.applyPixelFillCommand")
 
 ApplyPixelFillCommand::ApplyPixelFillCommand(TileCanvas *canvas, const QVector<QPoint> &scenePositions,
-    const QColor &previousColour, const QColor &colour, UndoCommand *parent) :
-    UndoCommand(parent),
+    const QColor &previousColour, const QColor &colour, QUndoCommand *parent) :
+    QUndoCommand(parent),
     mCanvas(canvas),
     mColour(colour)
 {
@@ -54,9 +54,9 @@ int ApplyPixelFillCommand::id() const
     return TileCanvas::PixelMode;
 }
 
-bool ApplyPixelFillCommand::mergeWith(const UndoCommand *other)
+bool ApplyPixelFillCommand::mergeWith(const QUndoCommand *other)
 {
-    const ApplyPixelFillCommand *otherCommand = qobject_cast<const ApplyPixelFillCommand*>(other);
+    const ApplyPixelFillCommand *otherCommand = dynamic_cast<const ApplyPixelFillCommand*>(other);
     if (!otherCommand) {
         return false;
     }

--- a/app/applypixelfillcommand.h
+++ b/app/applypixelfillcommand.h
@@ -24,23 +24,21 @@
 #include <QDebug>
 #include <QPoint>
 #include <QVector>
-#include <QtUndo/undocommand.h>
+#include <QUndoCommand>
 
 #include "tilecanvas.h"
 
-class ApplyPixelFillCommand : public UndoCommand
+class ApplyPixelFillCommand : public QUndoCommand
 {
-    Q_OBJECT
-
 public:
     ApplyPixelFillCommand(TileCanvas *canvas, const QVector<QPoint> &scenePositions, const QColor &previousColour,
-        const QColor &colour, UndoCommand *parent = nullptr);
+        const QColor &colour, QUndoCommand *parent = nullptr);
 
     void undo() override;
     void redo() override;
 
     int id() const override;
-    bool mergeWith(const UndoCommand *other) override;
+    bool mergeWith(const QUndoCommand *other) override;
 
 private:
     friend QDebug operator<<(QDebug debug, const ApplyPixelFillCommand &command);

--- a/app/applypixelpencommand.cpp
+++ b/app/applypixelpencommand.cpp
@@ -24,8 +24,8 @@
 Q_LOGGING_CATEGORY(lcApplyPixelPenCommand, "app.applyPixelPenCommand")
 
 ApplyPixelPenCommand::ApplyPixelPenCommand(TileCanvas *canvas, const QVector<QPoint> &scenePositions,
-    const QVector<QColor> &previousColours, const QColor &colour, UndoCommand *parent) :
-    UndoCommand(parent),
+    const QVector<QColor> &previousColours, const QColor &colour, QUndoCommand *parent) :
+    QUndoCommand(parent),
     mCanvas(canvas),
     mColour(colour)
 {
@@ -54,9 +54,9 @@ int ApplyPixelPenCommand::id() const
     return TileCanvas::PixelMode;
 }
 
-bool ApplyPixelPenCommand::mergeWith(const UndoCommand *other)
+bool ApplyPixelPenCommand::mergeWith(const QUndoCommand *other)
 {
-    const ApplyPixelPenCommand *otherCommand = qobject_cast<const ApplyPixelPenCommand*>(other);
+    const ApplyPixelPenCommand *otherCommand = dynamic_cast<const ApplyPixelPenCommand*>(other);
     if (!otherCommand) {
         return false;
     }

--- a/app/applypixelpencommand.h
+++ b/app/applypixelpencommand.h
@@ -24,23 +24,21 @@
 #include <QDebug>
 #include <QPoint>
 #include <QVector>
-#include <QtUndo/undocommand.h>
+#include <QUndoCommand>
 
 #include "tilecanvas.h"
 
-class ApplyPixelPenCommand : public UndoCommand
+class ApplyPixelPenCommand : public QUndoCommand
 {
-    Q_OBJECT
-
 public:
     ApplyPixelPenCommand(TileCanvas *canvas, const QVector<QPoint> &scenePositions, const QVector<QColor> &previousColours,
-        const QColor &colour, UndoCommand *parent = nullptr);
+        const QColor &colour, QUndoCommand *parent = nullptr);
 
     void undo() override;
     void redo() override;
 
     int id() const override;
-    bool mergeWith(const UndoCommand *other) override;
+    bool mergeWith(const QUndoCommand *other) override;
 
 private:
     friend QDebug operator<<(QDebug debug, const ApplyPixelPenCommand &command);

--- a/app/applytileerasercommand.cpp
+++ b/app/applytileerasercommand.cpp
@@ -26,8 +26,8 @@
 Q_LOGGING_CATEGORY(lcApplyTileEraserCommand, "app.applyTileEraserCommand")
 
 ApplyTileEraserCommand::ApplyTileEraserCommand(TileCanvas *canvas, const QPoint &tilePos,
-    int previousId, UndoCommand *parent) :
-    UndoCommand(parent),
+    int previousId, QUndoCommand *parent) :
+    QUndoCommand(parent),
     mCanvas(canvas)
 {
     mTilePositions.append(tilePos);
@@ -55,9 +55,9 @@ int ApplyTileEraserCommand::id() const
     return TileCanvas::TileMode;
 }
 
-bool ApplyTileEraserCommand::mergeWith(const UndoCommand *other)
+bool ApplyTileEraserCommand::mergeWith(const QUndoCommand *other)
 {
-    const ApplyTileEraserCommand *otherCommand = qobject_cast<const ApplyTileEraserCommand*>(other);
+    const ApplyTileEraserCommand *otherCommand = dynamic_cast<const ApplyTileEraserCommand*>(other);
     if (!otherCommand) {
         return false;
     }

--- a/app/applytileerasercommand.h
+++ b/app/applytileerasercommand.h
@@ -24,23 +24,21 @@
 #include <QDebug>
 #include <QPoint>
 #include <QVector>
-#include <QtUndo/undocommand.h>
+#include <QUndoCommand>
 
 #include "tilecanvas.h"
 
-class ApplyTileEraserCommand : public UndoCommand
+class ApplyTileEraserCommand : public QUndoCommand
 {
-    Q_OBJECT
-
 public:
     ApplyTileEraserCommand(TileCanvas *canvas, const QPoint &tilePos, int previousId,
-        UndoCommand *parent = nullptr);
+        QUndoCommand *parent = nullptr);
 
     void undo() override;
     void redo() override;
 
     int id() const override;
-    bool mergeWith(const UndoCommand *other) override;
+    bool mergeWith(const QUndoCommand *other) override;
 
 private:
     friend QDebug operator<<(QDebug debug, const ApplyTileEraserCommand &command);

--- a/app/applytilefillcommand.cpp
+++ b/app/applytilefillcommand.cpp
@@ -24,8 +24,8 @@
 Q_LOGGING_CATEGORY(lcApplyTileFillCommand, "app.applyTileFillCommand")
 
 ApplyTileFillCommand::ApplyTileFillCommand(TileCanvas *canvas, const QVector<QPoint> &tilePositions,
-    int previousTile, int tile, UndoCommand *parent) :
-    UndoCommand(parent),
+    int previousTile, int tile, QUndoCommand *parent) :
+    QUndoCommand(parent),
     mCanvas(canvas),
     mPreviousTile(previousTile),
     mTile(tile)
@@ -55,7 +55,7 @@ int ApplyTileFillCommand::id() const
     return TileCanvas::TileMode;
 }
 
-bool ApplyTileFillCommand::mergeWith(const UndoCommand *)
+bool ApplyTileFillCommand::mergeWith(const QUndoCommand *)
 {
     return false;
 }

--- a/app/applytilefillcommand.h
+++ b/app/applytilefillcommand.h
@@ -24,23 +24,21 @@
 #include <QDebug>
 #include <QPoint>
 #include <QVector>
-#include <QtUndo/undocommand.h>
+#include <QUndoCommand>
 
 #include "tilecanvas.h"
 
-class ApplyTileFillCommand : public UndoCommand
+class ApplyTileFillCommand : public QUndoCommand
 {
-    Q_OBJECT
-
 public:
     ApplyTileFillCommand(TileCanvas *canvas, const QVector<QPoint> &tilePositions, int previousTile,
-        int tile, UndoCommand *parent = nullptr);
+        int tile, QUndoCommand *parent = nullptr);
 
     void undo() override;
     void redo() override;
 
     int id() const override;
-    bool mergeWith(const UndoCommand *other) override;
+    bool mergeWith(const QUndoCommand *other) override;
 
 private:
     friend QDebug operator<<(QDebug debug, const ApplyTileFillCommand &command);

--- a/app/applytilepencommand.cpp
+++ b/app/applytilepencommand.cpp
@@ -24,8 +24,8 @@
 Q_LOGGING_CATEGORY(lcApplyTilePenCommand, "app.applyTilePenCommand")
 
 ApplyTilePenCommand::ApplyTilePenCommand(TileCanvas *canvas, const QPoint &tilePos,
-    int previousId, int id, UndoCommand *parent) :
-    UndoCommand(parent),
+    int previousId, int id, QUndoCommand *parent) :
+    QUndoCommand(parent),
     mCanvas(canvas),
     mId(id)
 {
@@ -54,9 +54,9 @@ int ApplyTilePenCommand::id() const
     return TileCanvas::TileMode;
 }
 
-bool ApplyTilePenCommand::mergeWith(const UndoCommand *other)
+bool ApplyTilePenCommand::mergeWith(const QUndoCommand *other)
 {
-    const ApplyTilePenCommand *otherCommand = qobject_cast<const ApplyTilePenCommand*>(other);
+    const ApplyTilePenCommand *otherCommand = dynamic_cast<const ApplyTilePenCommand*>(other);
     if (!otherCommand) {
         return false;
     }

--- a/app/applytilepencommand.h
+++ b/app/applytilepencommand.h
@@ -24,23 +24,21 @@
 #include <QDebug>
 #include <QPoint>
 #include <QVector>
-#include <QtUndo/undocommand.h>
+#include <QUndoCommand>
 
 #include "tilecanvas.h"
 
-class ApplyTilePenCommand : public UndoCommand
+class ApplyTilePenCommand : public QUndoCommand
 {
-    Q_OBJECT
-
 public:
     ApplyTilePenCommand(TileCanvas *canvas, const QPoint &tilePos, int previousId,
-        int id, UndoCommand *parent = nullptr);
+        int id, QUndoCommand *parent = nullptr);
 
     void undo() override;
     void redo() override;
 
     int id() const override;
-    bool mergeWith(const UndoCommand *other) override;
+    bool mergeWith(const QUndoCommand *other) override;
 
 private:
     friend QDebug operator<<(QDebug debug, const ApplyTilePenCommand &command);

--- a/app/changecanvassizecommand.cpp
+++ b/app/changecanvassizecommand.cpp
@@ -26,8 +26,8 @@
 Q_LOGGING_CATEGORY(lcChangeCanvasSizeCommand, "app.changeCanvasSizeCommand")
 
 ChangeCanvasSizeCommand::ChangeCanvasSizeCommand(Project *project, const QSize &previousSize,
-    const QSize &size, UndoCommand *parent) :
-    UndoCommand(parent),
+    const QSize &size, QUndoCommand *parent) :
+    QUndoCommand(parent),
     mProject(project),
     mPreviousSize(previousSize),
     mSize(size)

--- a/app/changecanvassizecommand.h
+++ b/app/changecanvassizecommand.h
@@ -23,17 +23,15 @@
 #include <QDebug>
 #include <QSize>
 #include <QVector>
-#include <QtUndo/undocommand.h>
+#include <QUndoCommand>
 
 class Project;
 
-class ChangeCanvasSizeCommand : public UndoCommand
+class ChangeCanvasSizeCommand : public QUndoCommand
 {
-    Q_OBJECT
-
 public:
     ChangeCanvasSizeCommand(Project *project, const QSize &previousSize, const QSize &size,
-        UndoCommand *parent = nullptr);
+        QUndoCommand *parent = nullptr);
 
     void undo() override;
     void redo() override;

--- a/app/project.cpp
+++ b/app/project.cpp
@@ -816,7 +816,7 @@ void Project::clearTiles()
     emit tilesCleared();
 }
 
-UndoStack *Project::undoStack()
+QUndoStack *Project::undoStack()
 {
     return &mUndoStack;
 }
@@ -859,13 +859,13 @@ void Project::endMacro()
     }
 }
 
-QDebug operator<<(QDebug debug, const UndoCommand &command)
+QDebug operator<<(QDebug debug, const QUndoCommand &command)
 {
     debug << &command;
     return debug;
 }
 
-void Project::addChange(UndoCommand *undoCommand)
+void Project::addChange(QUndoCommand *undoCommand)
 {
     qCDebug(lcProject) << "adding change" << *undoCommand;
     mUndoStack.push(undoCommand);

--- a/app/project.h
+++ b/app/project.h
@@ -27,7 +27,7 @@
 #include <QUrl>
 #include <QVector>
 
-#include <QtUndo/undostack.h>
+#include <QUndoStack>
 
 #include "tile.h"
 #include "tileset.h"
@@ -47,7 +47,7 @@ class Project : public QObject
     Q_PROPERTY(int tileHeight READ tileHeight NOTIFY tileHeightChanged)
     Q_PROPERTY(QUrl tilesetUrl READ tilesetUrl NOTIFY tilesetUrlChanged)
     Q_PROPERTY(Tileset *tileset READ tileset NOTIFY tilesetChanged)
-    Q_PROPERTY(UndoStack *undoStack READ undoStack CONSTANT)
+    Q_PROPERTY(QUndoStack *undoStack READ undoStack CONSTANT)
 
 public:
     Project();
@@ -100,12 +100,12 @@ public:
     // Sets all tiles to -1.
     void clearTiles();
 
-    UndoStack *undoStack();
+    QUndoStack *undoStack();
 
     bool isComposingMacro() const;
     void beginMacro(const QString &text);
     void endMacro();
-    void addChange(UndoCommand *undoCommand);
+    void addChange(QUndoCommand *undoCommand);
     void clearChanges();
 
 signals:
@@ -170,7 +170,7 @@ private:
     QTemporaryDir mTempDir;
     bool mUsingTempTilesetImage;
 
-    UndoStack mUndoStack;
+    QUndoStack mUndoStack;
     bool mComposingMacro;
     bool mHadUnsavedChangesBeforeMacroBegan;
 };

--- a/app/tilecanvas.h
+++ b/app/tilecanvas.h
@@ -26,7 +26,7 @@
 #include <QStack>
 #include <QWheelEvent>
 
-#include <QtUndo/undostack.h>
+#include <QUndoStack>
 
 #include "splitter.h"
 #include "tilecanvaspane.h"


### PR DESCRIPTION
Avoids a dependency, at least while QtWidgets is used anyway.