### PR TITLE
Cursor work

### DIFF
--- a/app/qml/ui/CanvasContainer.qml
+++ b/app/qml/ui/CanvasContainer.qml
@@ -53,7 +53,7 @@ Item {
         y: canvas ? canvas.cursorY - height / 2 : 0
         z: 1
         colour: canvas ? canvas.invertedCursorPixelColour : defaultColour
-        visible: canvas && canvas.hasBlankCursor && !canvas.useIconCursor && canvas.useCrosshairCursor
+        visible: canvas && canvas.hasBlankCursor && !canvas.useIconCursor && (canvas.useCrosshairCursor || settings.alwaysShowCrosshair)
     }
 
     RectangularCursor {

--- a/app/qml/ui/OptionsDialog.qml
+++ b/app/qml/ui/OptionsDialog.qml
@@ -24,6 +24,7 @@ Dialog {
         settings.autoSwatchEnabled = enableAutoSwatchCheckBox.checked
         settings.checkerColour1 = checkerColour1TextField.colour
         settings.checkerColour2 = checkerColour2TextField.colour
+        settings.alwaysShowCrosshair = alwaysShowCrosshairCheckBox.checked
         settings.fpsVisible = showFpsCheckBox.checked
         settings.windowOpacity = windowOpacitySlider.value
 
@@ -42,6 +43,7 @@ Dialog {
         checkerColour1TextField.text = settings.checkerColour1
         checkerColour2TextField.text = settings.checkerColour2
         showFpsCheckBox.checked = settings.fpsVisible
+        alwaysShowCrosshairCheckBox.checked = settings.alwaysShowCrosshair
         windowOpacitySlider.value = settings.windowOpacity
 
         for (var i = 0; i < shortcutModel.count; ++i) {
@@ -206,6 +208,19 @@ Dialog {
                         id: showFpsCheckBox
                         leftPadding: 0
                         checked: settings.fpsVisible
+                    }
+
+                    Label {
+                        text: qsTr("Always show crosshair cursor")
+                    }
+                    CheckBox {
+                        id: alwaysShowCrosshairCheckBox
+                        leftPadding: 0
+                        checked: settings.alwaysShowCrosshair
+
+                        ToolTip.text: qsTr("Don't hide crosshair cursor when rectangle cursor is visible")
+                        ToolTip.visible: hovered
+                        ToolTip.delay: toolTipDelay
                     }
 
                     Label {

--- a/app/qml/ui/OptionsDialog.qml
+++ b/app/qml/ui/OptionsDialog.qml
@@ -80,6 +80,8 @@ Dialog {
             }
 
             ScrollView {
+                clip: true
+
                 ScrollBar.horizontal.policy: ScrollBar.AsNeeded
 
                 Layout.fillWidth: true

--- a/lib/applicationsettings.cpp
+++ b/lib/applicationsettings.cpp
@@ -323,6 +323,31 @@ void ApplicationSettings::setAutoSwatchEnabled(bool autoSwatchEnabled)
     emit autoSwatchEnabledChanged();
 }
 
+bool ApplicationSettings::defaultAlwaysShowCrosshair() const
+{
+    return false;
+}
+
+bool ApplicationSettings::isAlwaysShowCrosshair() const
+{
+    return contains("alwaysShowCrosshair") ? value("alwaysShowCrosshair").toBool() : defaultAlwaysShowCrosshair();
+}
+
+void ApplicationSettings::setAlwaysShowCrosshair(bool alwaysShowCrosshair)
+{
+    const QVariant existingValue = value("alwaysShowCrosshair");
+    bool existingBoolValue = defaultAlwaysShowCrosshair();
+    if (contains("alwaysShowCrosshair")) {
+        existingBoolValue = existingValue.toBool();
+    }
+
+    if (alwaysShowCrosshair == existingBoolValue)
+        return;
+
+    setValue("alwaysShowCrosshair", alwaysShowCrosshair);
+    emit alwaysShowCrosshairChanged();
+}
+
 qreal ApplicationSettings::defaultWindowOpacity() const
 {
     return 1.0;

--- a/lib/applicationsettings.h
+++ b/lib/applicationsettings.h
@@ -46,6 +46,7 @@ class SLATE_EXPORT ApplicationSettings : public QSettings
     Q_PROPERTY(bool fpsVisible READ isFpsVisible WRITE setFpsVisible NOTIFY fpsVisibleChanged)
     Q_PROPERTY(bool gesturesEnabled READ areGesturesEnabled WRITE setGesturesEnabled NOTIFY gesturesEnabledChanged)
     Q_PROPERTY(bool autoSwatchEnabled READ isAutoSwatchEnabled WRITE setAutoSwatchEnabled NOTIFY autoSwatchEnabledChanged)
+    Q_PROPERTY(bool alwaysShowCrosshair READ isAlwaysShowCrosshair WRITE setAlwaysShowCrosshair NOTIFY alwaysShowCrosshairChanged)
     Q_PROPERTY(qreal windowOpacity READ windowOpacity WRITE setWindowOpacity NOTIFY windowOpacityChanged)
     Q_PROPERTY(QColor checkerColour1 READ checkerColour1 WRITE setCheckerColour1 NOTIFY checkerColour1Changed)
     Q_PROPERTY(QColor checkerColour2 READ checkerColour2 WRITE setCheckerColour2 NOTIFY checkerColour2Changed)
@@ -133,6 +134,10 @@ public:
     bool defaultAutoSwatchEnabled() const;
     bool isAutoSwatchEnabled() const;
     void setAutoSwatchEnabled(bool autoSwatchEnabled);
+
+    bool defaultAlwaysShowCrosshair() const;
+    bool isAlwaysShowCrosshair() const;
+    void setAlwaysShowCrosshair(bool alwaysShowCrosshair);
 
     qreal defaultWindowOpacity() const;
     qreal windowOpacity() const;
@@ -307,6 +312,7 @@ signals:
     void fpsVisibleChanged();
     void gesturesEnabledChanged();
     void autoSwatchEnabledChanged();
+    void alwaysShowCrosshairChanged();
     void windowOpacityChanged();
     void checkerColour1Changed();
     void checkerColour2Changed();


### PR DESCRIPTION
Add option to always show crosshair cursor as I find I often loose track of the rectangle cursor at low zoom levels.

Snap rectangle cursor to pixel. Doesn't position properly on second split pane, can't figure out how to get the offset of the second pane.