### PR TITLE
Fix splitter and ruler geometry updating

### DIFF
--- a/lib/tilecanvas.cpp
+++ b/lib/tilecanvas.cpp
@@ -225,12 +225,6 @@ bool TileCanvas::supportsSelectionTool() const
     return false;
 }
 
-void TileCanvas::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
-{
-    QQuickItem::geometryChanged(newGeometry, oldGeometry);
-    centrePanes();
-}
-
 TileCanvas::PixelCandidateData TileCanvas::penEraserPixelCandidates(Tool tool) const
 {
     PixelCandidateData candidateData;

--- a/lib/tilecanvas.h
+++ b/lib/tilecanvas.h
@@ -94,8 +94,6 @@ protected:
     void toolChange() override;
     bool supportsSelectionTool() const override;
 
-    void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) override;
-
     void onLoadedChanged() override;
 
 private:


### PR DESCRIPTION
Fix splitter and ruler geometry not updating when window size changed in tile projects.
Just an unnecessary override of geometryChanged in TileCanvas.