### PR TITLE
Fix html creation on webassembly

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -5,7 +5,7 @@ if(WIN32)
         WIN32
     )
 else()
-    add_executable(
+    qt_add_executable(
         app
     )
 endif()


### PR DESCRIPTION
qt_add_executable needs to be used for cmake to copy and
generate html and qtloader.js files.