### PR TITLE
Fix installed Qt translator lifetime

### DIFF
--- a/app/application.cpp
+++ b/app/application.cpp
@@ -199,10 +199,13 @@ void Application::installTranslators()
             qWarning() << "Failed to load slate_* translation for locale"
                 << locale.name() << "from" << slateTranslationsDir.absolutePath();
         }
+        delete slateTranslator;
     }
 
     const QString qtTranslationsDir = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
-    std::unique_ptr<QTranslator> qtTranslator(new QTranslator(mApplication.data()));
+    QTranslator *qtTranslator = new QTranslator(mApplication.data());
     if (qtTranslator->load(locale, QStringLiteral("qt_"), QString(), qtTranslationsDir))
-        mApplication->installTranslator(qtTranslator.get());
+        mApplication->installTranslator(qtTranslator);
+    else
+        delete qtTranslator;
 }


### PR DESCRIPTION
I noticed that the Qt translator installed in `Application::installTranslators()` was stored in a local `std::unique_ptr`. Since `installTranslator()` does not take ownership, the translator appears to be destroyed when the function returns.

This patch keeps the translator alive by parenting it to the application, matching the ownership style used for the Slate translator. Translators that fail to load are deleted immediately.