### PR TITLE
Fix QML Animation type ambiguity between QtQuick and Slate

### DIFF
--- a/app/qml/ui/ShortcutRow.qml
+++ b/app/qml/ui/ShortcutRow.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-import Slate
+import Slate as Slate
 
 RowLayout {
     objectName: shortcutName + "Row"
@@ -26,7 +26,7 @@ RowLayout {
         Layout.fillWidth: true
     }
 
-    KeySequenceEditor {
+    Slate.KeySequenceEditor {
         id: editor
         objectName: shortcutName + "Editor"
         enabled: shortcutName.length > 0


### PR DESCRIPTION
Unable to assign [undefined] to int was reported because Animation.Infinite
resolved to the wrong Animation type due to a name collision between QtQuick
and Slate modules.

Import Slate with an alias to make the reference unambiguous.